### PR TITLE
disable hard-link counting in benchmarks where possible

### DIFF
--- a/ci/github-actions/benchmark/matrix.ts
+++ b/ci/github-actions/benchmark/matrix.ts
@@ -94,10 +94,10 @@ export const COMPETING_BENCHMARK_MATRIX: readonly CompetingBenchmarkCategory[] =
     pduCliArgs: ['--quantity=len'],
     competitors: [
       ['dust', '--apparent-size'],
-      ['dua', '--apparent-size'],
+      ['dua', '-l', '--apparent-size'],
       ['ncdu', '-o', '/dev/stdout', '-0'],
-      ['gdu', '--show-apparent-size', '--non-interactive', '--no-progress'],
-      ['du', '--apparent-size'],
+      ['gdu', '-l', '--show-apparent-size', '--non-interactive', ,'--no-progress'],
+      ['du', '-l', '--apparent-size'],
     ],
   },
   {
@@ -105,10 +105,10 @@ export const COMPETING_BENCHMARK_MATRIX: readonly CompetingBenchmarkCategory[] =
     pduCliArgs: ['--quantity=blksize'],
     competitors: [
       ['dust'],
-      ['dua'],
+      ['dua', '-l'],
       ['ncdu', '-o', '/dev/stdout', '-0'],
-      ['gdu', '--non-interactive', '--no-progress'],
-      ['du'],
+      ['gdu', '-l', '--non-interactive', '--no-progress'],
+      ['du', '-l'],
     ],
   },
   {
@@ -123,8 +123,8 @@ export const COMPETING_BENCHMARK_MATRIX: readonly CompetingBenchmarkCategory[] =
     pduCliArgs: ['--max-depth=1'],
     competitors: [
       ['dutree', '--summary'],
-      ['dua', '--apparent-size'],
-      ['du', '--apparent-size', '--summarize'],
+      ['dua', '-l', '--apparent-size'],
+      ['du', '-l', '--apparent-size', '--summarize'],
     ],
   },
   {
@@ -133,27 +133,27 @@ export const COMPETING_BENCHMARK_MATRIX: readonly CompetingBenchmarkCategory[] =
     competitors: [
       ['dutree'],
       ['ncdu', '-o', '/dev/stdout', '-0'],
-      ['du', '--apparent-size'],
+      ['du', '-l', '--apparent-size'],
     ],
   },
   {
     id: 'no-sort',
     pduCliArgs: ['--no-sort'],
     competitors: [
-      ['du', '--apparent-size'],
-      ['dua', '--apparent-size'],
+      ['du', '-l', '--apparent-size'],
+      ['dua', '-l', '--apparent-size'],
       ['ncdu', '-o', '/dev/stdout', '-0'],
-      ['gdu', '--show-apparent-size', '--non-interactive', '--no-progress'],
+      ['gdu', '-l', '--show-apparent-size', '--non-interactive', '--no-progress'],
     ],
   },
   {
     id: 'no-sort+summary',
     pduCliArgs: ['--no-sort', '--max-depth=1'],
     competitors: [
-      ['dua', '--apparent-size'],
+      ['dua', '-l', '--apparent-size'],
       ['ncdu', '-o', '/dev/null', '-0'],
-      ['gdu', '--show-apparent-size', '--non-interactive', '--no-progress'],
-      ['du', '--apparent-size', '--summarize'],
+      ['gdu','-l', '--show-apparent-size', '--non-interactive', '--no-progress'],
+      ['du', '-l', '--apparent-size', '--summarize'],
     ],
   },
   {
@@ -161,7 +161,7 @@ export const COMPETING_BENCHMARK_MATRIX: readonly CompetingBenchmarkCategory[] =
     pduCliArgs: ['--progress'],
     competitors: [
       ['ncdu', '-o', '/dev/stdout', '-1'],
-      ['gdu', '--show-apparent-size', '--non-interactive'],
+      ['gdu', '-l', '--show-apparent-size', '--non-interactive'],
     ],
   },
 ]


### PR DESCRIPTION
According to PDUs limitations, it will count each hard-link to a file.
As the correct handling of hard-links isn't free, I think it makes sense
to count hard-links in all tools that support it.

All of those which support it have the `-l` flag added to them. It was chosen
over its long form to avoid making the command-line for `gdu` even longer and reduce
the bar size the least amount possible.

Please note that `ncdu` doesn't allow to disable hard-link counting, while `dust` doesn't
support it either.

----

I am ramping up for a new round in the benchmark and thought in preparation I could try to level
the playing field a little more. My hope is to reach a second place at least.

Here is the upcoming version of `dua`: https://github.com/Byron/dua-cli/pull/158 , which ditches `jwalk`
for `moonwalk`.

Here is some results from a linux VM which show it's really close now. `dua-lite` is a no-extras version
of `dua` just to see how fast it could go.

Let me also mention that I use `pdu`(and loving it!) just as much as `dua` and think that this friendly competition helps
to improve both tools, benefiting all :).
